### PR TITLE
dev: add missing: parsley

### DIFF
--- a/dev.yaml
+++ b/dev.yaml
@@ -54,6 +54,7 @@ packages:
   - namedlist
   - nictools
   - opuscoords
+  - parsley
   - photutils
   - poppy
   - purge_path


### PR DESCRIPTION
Recipe exists, and packages exist in the dev channel, but there wasn't an entry in the build manifests. 

Strange.