### PR TITLE
Correct old repository URL employed during development.

### DIFF
--- a/jwst.yaml
+++ b/jwst.yaml
@@ -1,5 +1,5 @@
 # Recipe repository
-repository: 'https://github.com/rendinam/astroconda-dev'
+repository: 'https://github.com/astroconda/astroconda-dev'
 git_ref_spec: 'master'
 
 # Publication channel to consult when determining what packages already exist.


### PR DESCRIPTION
The old URL had a repository out of date with respect to the official Astroconda repo. This resulted in the lastest JWSTDP delivery build using an out of date recipe for the `jwst` package, creating spec files for py36 that were missing the `pymssql` dependency, since the recipe in the erroneous commit explicitly disabled acquisition of that dependency on py36. The builds for the other python versions were not affected.