### PR TITLE
public-test: Use astroconda-contrib staging branch

### DIFF
--- a/public-test.yaml
+++ b/public-test.yaml
@@ -1,6 +1,6 @@
 # Recipe repository
 repository: 'https://github.com/astroconda/astroconda-contrib'
-git_ref_spec: 'master'
+git_ref_spec: 'staging'
 
 # Publication channel to consult when determining what packages already exist.
 channel_URL: 'http://ssb.stsci.edu/astroconda'
@@ -8,4 +8,4 @@ channel_URL: 'http://ssb.stsci.edu/astroconda'
 # publication_root path needs to be visible from the slave nodes.
 publication_root: '/eng/ssb/websites/ssbpublic/astroconda-j-pub-staging'
 packages:
-  - asdf
+  - hstcal


### PR DESCRIPTION
When dev goes away we'll need a way to stage a deliverable without actually releasing it. So it may be possible to use `astroconda/staging` to build tags (because the new release workflow does not play nice with `git describe` anyway, so dev is useless here). 